### PR TITLE
Fix `clippy::useless_vec` warning in previous PR

### DIFF
--- a/libsqlite3-sys/build.rs
+++ b/libsqlite3-sys/build.rs
@@ -284,7 +284,7 @@ mod build_bundled {
                 .flag("-DSQLITE_OMIT_LOCALTIME")
                 .flag("-Wno-incompatible-library-redeclaration");
 
-            let supported_features = vec![
+            let supported_features = [
                 "atomics",
                 "bulk-memory",
                 "exception-handling",


### PR DESCRIPTION
Apologies -- I didn't pass the right feature flags to `cargo clippy` when running it on the last PR.